### PR TITLE
Improve modal dialog layout for long text

### DIFF
--- a/modules/game_modaldialog/modaldialog.lua
+++ b/modules/game_modaldialog/modaldialog.lua
@@ -50,7 +50,7 @@ function onModalDialog(id, title, message, buttons, enterButton, escapeButton, c
     messageLabel:setText(message)
 
     local choiceLabels = {}
-    local baseChoiceLabelHeight
+    local baseChoiceLabelHeight = 0
     for i = 1, #choices do
         local choiceId = choices[i][1]
         local choiceName = choices[i][2]
@@ -59,7 +59,7 @@ function onModalDialog(id, title, message, buttons, enterButton, escapeButton, c
         label.choiceId = choiceId
         label:setText(choiceName)
         label:setPhantom(false)
-        if not baseChoiceLabelHeight then
+        if baseChoiceLabelHeight == 0 or math.min(baseChoiceLabelHeight, label:getHeight()) == label:getHeight() then
             baseChoiceLabelHeight = label:getHeight()
         end
         table.insert(choiceLabels, label)
@@ -162,7 +162,7 @@ function onModalDialog(id, title, message, buttons, enterButton, escapeButton, c
                 heightForMaxChoices = heightForMaxChoices + height
             end
         end
-
+        
         local choiceContentHeight = totalChoiceHeight
         if #choiceLabels > modalDialog.maximumChoices then
             choiceContentHeight = heightForMaxChoices
@@ -171,7 +171,7 @@ function onModalDialog(id, title, message, buttons, enterButton, escapeButton, c
         if baseChoiceLabelHeight and baseChoiceLabelHeight > 0 then
             choiceContentHeight = math.max(choiceContentHeight, modalDialog.minimumChoices * baseChoiceLabelHeight)
         end
-
+        
         local listInnerHeight = choiceContentHeight + choiceList:getPaddingTop() + choiceList:getPaddingBottom()
         choiceList:setHeight(listInnerHeight)
 

--- a/modules/game_modaldialog/modaldialog.lua
+++ b/modules/game_modaldialog/modaldialog.lua
@@ -41,10 +41,16 @@ function onModalDialog(id, title, message, buttons, enterButton, escapeButton, c
     local choiceScrollbar = modalDialog:getChildById('choiceScrollBar')
     local buttonsPanel = modalDialog:getChildById('buttonsPanel')
 
+    local baseDialogHeight = modalDialog:getHeight()
+    local baseMessageHeight = messageLabel:getHeight()
+    local baseChoiceListHeight = choiceList:getHeight()
+    local baseChoiceListArea = baseChoiceListHeight + choiceList:getMarginTop() + choiceList:getMarginBottom()
+
     modalDialog:setText(title)
     messageLabel:setText(message)
 
-    local labelHeight
+    local choiceLabels = {}
+    local baseChoiceLabelHeight
     for i = 1, #choices do
         local choiceId = choices[i][1]
         local choiceName = choices[i][2]
@@ -53,11 +59,16 @@ function onModalDialog(id, title, message, buttons, enterButton, escapeButton, c
         label.choiceId = choiceId
         label:setText(choiceName)
         label:setPhantom(false)
-        if not labelHeight then
-            labelHeight = label:getHeight()
+        if not baseChoiceLabelHeight then
+            baseChoiceLabelHeight = label:getHeight()
         end
+        table.insert(choiceLabels, label)
     end
-    choiceList:focusChild(choiceList:getFirstChild())
+
+    local firstChoice = choiceList:getFirstChild()
+    if firstChoice then
+        choiceList:focusChild(firstChoice)
+    end
 
     g_keyboard.bindKeyPress('Down', function()
         choiceList:focusNextChild(KeyboardFocusReason)
@@ -66,7 +77,7 @@ function onModalDialog(id, title, message, buttons, enterButton, escapeButton, c
         choiceList:focusPreviousChild(KeyboardFocusReason)
     end, modalDialog)
 
-    local buttonsWidth = 0
+    local buttonsWidth = buttonsPanel:getPaddingLeft() + buttonsPanel:getPaddingRight()
     for i = 1, #buttons do
         local buttonId = buttons[i][1]
         local buttonText = buttons[i][2]
@@ -88,22 +99,82 @@ function onModalDialog(id, title, message, buttons, enterButton, escapeButton, c
     local additionalHeight = 0
     if #choices > 0 then
         choiceList:setVisible(true)
-        choiceScrollbar:setVisible(true)
-
-        additionalHeight = math.min(modalDialog.maximumChoices, math.max(modalDialog.minimumChoices, #choices)) *
-                               labelHeight
-        additionalHeight = additionalHeight + choiceList:getPaddingTop() + choiceList:getPaddingBottom() + 10
     end
 
     local horizontalPadding = modalDialog:getPaddingLeft() + modalDialog:getPaddingRight()
-    buttonsWidth = buttonsWidth + horizontalPadding
+    local messageWidth = messageLabel:getTextSize().width + messageLabel:getPaddingLeft() + messageLabel:getPaddingRight()
+    local choiceListPadding = choiceList:getPaddingLeft() + choiceList:getPaddingRight()
+    local choiceListMargins = choiceList:getMarginLeft() + choiceList:getMarginRight()
 
-    modalDialog:setWidth(math.min(modalDialog.maximumWidth,
-                                  math.max(buttonsWidth, messageLabel:getWidth(), modalDialog.minimumWidth)))
-    messageLabel:setWidth(math.min(modalDialog.maximumWidth,
-                                   math.max(buttonsWidth, messageLabel:getWidth(), modalDialog.minimumWidth)) -
-                              horizontalPadding)
-    modalDialog:setHeight(modalDialog:getHeight() + additionalHeight + messageLabel:getHeight() - 8)
+    local requiresScrollbar = #choices > modalDialog.maximumChoices
+    choiceScrollbar:setVisible(requiresScrollbar and #choices > 0)
+    local scrollbarWidth = 0
+    if choiceScrollbar:isVisible() then
+        scrollbarWidth = choiceScrollbar:getWidth()
+        if scrollbarWidth == 0 then
+            scrollbarWidth = 20
+        end
+    end
+
+    local choicesWidth = 0
+    for _, label in ipairs(choiceLabels) do
+        local labelWidth = label:getTextSize().width + label:getPaddingLeft() + label:getPaddingRight() +
+            label:getMarginLeft() + label:getMarginRight()
+        choicesWidth = math.max(choicesWidth, labelWidth)
+    end
+
+    local dialogWidth = math.max(modalDialog.minimumWidth, buttonsWidth + horizontalPadding,
+        messageWidth + horizontalPadding)
+    if choicesWidth > 0 then
+        dialogWidth = math.max(dialogWidth,
+            choicesWidth + choiceListPadding + choiceListMargins + scrollbarWidth + horizontalPadding)
+    end
+
+    if modalDialog.maximumWidth > 0 then
+        dialogWidth = math.min(dialogWidth, modalDialog.maximumWidth)
+    end
+
+    modalDialog:setWidth(dialogWidth)
+    messageLabel:setWidth(dialogWidth - horizontalPadding)
+
+    if #choiceLabels > 0 then
+        local availableChoiceWidth = dialogWidth - horizontalPadding - choiceListPadding - scrollbarWidth
+        for _, label in ipairs(choiceLabels) do
+            local width = math.max(0, availableChoiceWidth - label:getMarginLeft() - label:getMarginRight())
+            label:setWidth(width)
+        end
+
+        local totalChoiceHeight = 0
+        local heightForMaxChoices = 0
+        for index, label in ipairs(choiceLabels) do
+            local height = label:getHeight()
+            totalChoiceHeight = totalChoiceHeight + height
+            if index <= modalDialog.maximumChoices then
+                heightForMaxChoices = heightForMaxChoices + height
+            end
+        end
+
+        local choiceContentHeight = totalChoiceHeight
+        if #choiceLabels > modalDialog.maximumChoices then
+            choiceContentHeight = heightForMaxChoices
+        end
+
+        if baseChoiceLabelHeight and baseChoiceLabelHeight > 0 then
+            choiceContentHeight = math.max(choiceContentHeight, modalDialog.minimumChoices * baseChoiceLabelHeight)
+        end
+
+        local listInnerHeight = choiceContentHeight + choiceList:getPaddingTop() + choiceList:getPaddingBottom()
+        choiceList:setHeight(listInnerHeight)
+
+        local desiredChoiceArea = listInnerHeight + choiceList:getMarginTop() + choiceList:getMarginBottom()
+        local baseChoiceArea = baseChoiceListArea
+        additionalHeight = math.max(0, desiredChoiceArea - baseChoiceArea)
+    else
+        choiceScrollbar:setVisible(false)
+    end
+
+    local messageHeightDelta = math.max(0, messageLabel:getHeight() - baseMessageHeight)
+    modalDialog:setHeight(baseDialogHeight + additionalHeight + messageHeightDelta)
 
     local enterFunc = function()
         local focusedChoice = choiceList:getFocusedChild()

--- a/modules/game_modaldialog/modaldialog.lua
+++ b/modules/game_modaldialog/modaldialog.lua
@@ -135,7 +135,16 @@ function onModalDialog(id, title, message, buttons, enterButton, escapeButton, c
     end
 
     modalDialog:setWidth(dialogWidth)
-    messageLabel:setWidth(dialogWidth - horizontalPadding)
+
+    local messageAreaWidth = math.max(0, dialogWidth - horizontalPadding)
+    messageLabel:setWidth(messageAreaWidth)
+    if messageLabel:getText():len() > 0 then
+        messageLabel:setText('', true)
+        messageLabel:setText(message)
+    end
+
+    local messageHeight = messageLabel:getTextSize().height + messageLabel:getPaddingTop() + messageLabel:getPaddingBottom()
+    messageLabel:setHeight(messageHeight)
 
     if #choiceLabels > 0 then
         local availableChoiceWidth = dialogWidth - horizontalPadding - choiceListPadding - scrollbarWidth


### PR DESCRIPTION
## Summary
- dynamically size modal dialogs based on message and choice content
- wrap long choice texts and adjust available width so options remain readable
- extend choice list height calculations to show multiline options without clipping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfb73120e48332ba6e6ee66b41ca5f