### PR TITLE
Support item rarity metadata from XML

### DIFF
--- a/modules/game_cyclopedia/tab/items/items.lua
+++ b/modules/game_cyclopedia/tab/items/items.lua
@@ -268,13 +268,8 @@ function Cyclopedia.internalCreateItem(data)
         UI.InfoBase.ResultGoldBase.Value:setText(Cyclopedia.formatGold(item.Value))
         UI.SelectedItem.Sprite:setItemId(data:getId())
 
-        if price > 0 then
-            ItemsDatabase.setRarityItem(UI.SelectedItem.Rarity, price)
-            ItemsDatabase.setRarityItem(UI.InfoBase.ResultGoldBase.Rarity, price)
-        else
-            UI.InfoBase.ResultGoldBase.Rarity:setImageSource("")
-            UI.SelectedItem.Rarity:setImageSource("")
-        end
+        ItemsDatabase.setRarityItem(UI.SelectedItem.Rarity, internalData)
+        ItemsDatabase.setRarityItem(UI.InfoBase.ResultGoldBase.Rarity, internalData)
         widget:setBackgroundColor("#585858")
        
         if modules.game_quickloot.QuickLoot.data.filter == 2 then

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -97,6 +97,10 @@ public:
     uint32_t getDurationTime() { return m_durationTime; }
     uint32_t getCharges() { return m_charges; }
     uint8_t getTier() { return m_tier; }
+    uint8_t getRarity() {
+        const auto* thingType = getThingType();
+        return thingType ? thingType->getRarity() : 1;
+    }
 
     bool isValid() { return getThingType() != nullptr; }
 

--- a/src/client/luafunctions.cpp
+++ b/src/client/luafunctions.cpp
@@ -696,6 +696,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<ThingType>("getMarketData", &ThingType::getMarketData);
     g_lua.bindClassMemberFunction<ThingType>("getNpcSaleData", &ThingType::getNpcSaleData);
     g_lua.bindClassMemberFunction<ThingType>("getMeanPrice", &ThingType::getMeanPrice);
+    g_lua.bindClassMemberFunction<ThingType>("getRarity", &ThingType::getRarity);
     g_lua.bindClassMemberFunction<ThingType>("isUsable", &ThingType::isUsable);
     g_lua.bindClassMemberFunction<ThingType>("isWrapable", &ThingType::isWrapable);
     g_lua.bindClassMemberFunction<ThingType>("isUnwrapable", &ThingType::isUnwrapable);
@@ -738,6 +739,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Item>("getMarketData", &Item::getMarketData);
     g_lua.bindClassMemberFunction<Item>("getNpcSaleData", &Item::getNpcSaleData);
     g_lua.bindClassMemberFunction<Item>("getMeanPrice", &Item::getMeanPrice);
+    g_lua.bindClassMemberFunction<Item>("getRarity", &Item::getRarity);
     g_lua.bindClassMemberFunction<Item>("getClothSlot", &Item::getClothSlot);
     g_lua.bindClassMemberFunction<Item>("hasWearOut", &ThingType::hasWearOut);
     g_lua.bindClassMemberFunction<Item>("hasClockExpire", &ThingType::hasClockExpire);

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -29,6 +29,7 @@
 #include <framework/graphics/drawpoolmanager.h>
 #include <framework/luaengine/luaobject.h>
 #include <framework/otml/declarations.h>
+#include <algorithm>
 #include <variant>
 
 using namespace otclient::protobuf;
@@ -350,6 +351,9 @@ public:
     const Light& getLight() { return m_light; }
     const MarketData& getMarketData() { return m_market; }
     const std::vector<NPCData>& getNpcSaleData() { return m_npcData; }
+    uint8_t getRarity() const { return m_rarity; }
+    void setRarity(const uint8_t rarity) { m_rarity = std::max<uint8_t>(rarity, 1); }
+
     int getMeanPrice() {
         static constexpr std::array<std::pair<uint32_t, uint32_t>, 3> forcedPrices = { {
             {3043, 10000},
@@ -515,6 +519,7 @@ private:
     uint8_t m_clothSlot{ 0 };
     uint8_t m_lensHelp{ 0 };
     uint8_t m_elevation{ 0 };
+    uint8_t m_rarity{ 1 };
 
     PLAYER_ACTION m_defaultAction{ 0 };
 

--- a/src/client/thingtypemanager.h
+++ b/src/client/thingtypemanager.h
@@ -95,6 +95,10 @@ private:
     uint32_t m_datSignature{ 0 };
     uint16_t m_contentRevision{ 0 };
 
+    void loadItemRarities(const std::string& basePath = "");
+    bool loadItemRaritiesFromXml(const std::string& filePath);
+    void applyRarityToItem(uint16_t serverId, uint8_t rarity);
+
 #ifdef FRAMEWORK_EDITOR
     ItemTypePtr m_nullItemType;
     ItemTypeList m_reverseItemTypes;


### PR DESCRIPTION
## Summary
- parse rarity information from items.xml and load it when reading dat or appearance assets
- expose item rarity to Lua via ThingType/Item bindings and update item widgets to use the new rarity images
- refresh cyclopedia panels and loot text coloring to rely on the new rarity data

## Testing
- cmake --preset linux-release *(fails: missing /scripts/buildsystems/vcpkg.cmake and Ninja)*

------
https://chatgpt.com/codex/tasks/task_e_68d1665702148332b12c3f227d5003c6