### PR TITLE
Add UTF-8 text pipeline with Polish charset support

### DIFF
--- a/data/fonts/verdana-11px-antialised.otfont
+++ b/data/fonts/verdana-11px-antialised.otfont
@@ -1,6 +1,9 @@
 Font
   name: verdana-11px-antialised
-  texture: verdana-11px-antialised_cp1252
+  charset: cp1252
+  charsets:
+    cp1252: verdana-11px-antialised_cp1252
+    cp1250: verdana-11px-antialised_cp1250
   height: 14
   glyph-size: 16 16
   space-width: 4

--- a/data/fonts/verdana-11px-monochrome.otfont
+++ b/data/fonts/verdana-11px-monochrome.otfont
@@ -1,6 +1,9 @@
 Font
   name: verdana-11px-monochrome
-  texture: verdana-11px-monochrome_cp1252
+  charset: cp1252
+  charsets:
+    cp1252: verdana-11px-monochrome_cp1252
+    cp1250: verdana-11px-monochrome_cp1250
   height: 14
   glyph-size: 16 16
   space-width: 3

--- a/data/fonts/verdana-11px-rounded.otfont
+++ b/data/fonts/verdana-11px-rounded.otfont
@@ -1,6 +1,9 @@
 Font
   name: verdana-11px-rounded
-  texture: verdana-11px-rounded_cp1252
+  charset: cp1252
+  charsets:
+    cp1252: verdana-11px-rounded_cp1252
+    cp1250: verdana-11px-rounded_cp1250
   height: 16
   glyph-size: 16 16
   y-offset: -2

--- a/data/locales/pl.lua
+++ b/data/locales/pl.lua
@@ -1,5 +1,6 @@
 locale = {
   name = "pl",
+  charset = "cp1250",
   languageName = "Polski",
 
   formatNumbers = true,

--- a/modules/client_locales/locales.lua
+++ b/modules/client_locales/locales.lua
@@ -185,6 +185,11 @@ function setLocale(name)
         sendLocale(locale.name)
     end
     currentLocale = locale
+    if locale.charset then
+        g_app.setCharset(locale.charset)
+    else
+        g_app.setCharset('cp1252')
+    end
     g_settings.set('locale', name)
     if onLocaleChanged then
         onLocaleChanged(name)

--- a/src/framework/core/application.cpp
+++ b/src/framework/core/application.cpp
@@ -40,6 +40,7 @@
 #define ADD_QUOTES(s) ADD_QUOTES_HELPER(s)
 
 #include <locale>
+#include <framework/stdext/string.h>
 
 #ifdef FRAMEWORK_NET
 #ifdef __EMSCRIPTEN__
@@ -108,6 +109,12 @@ void Application::init(std::vector<std::string>& args, ApplicationContext* conte
 
     // initalize proxy
     g_proxy.init();
+}
+
+void Application::setCharset(const std::string_view charset)
+{
+    m_charset = charset;
+    stdext::tolower(m_charset);
 }
 
 void Application::deinit()

--- a/src/framework/core/application.h
+++ b/src/framework/core/application.h
@@ -51,6 +51,7 @@ public:
         m_appName += " (DEBUG MODE)";
 #endif
     }
+    void setCharset(const std::string_view charset);
     void setCompactName(const std::string_view name) { m_appCompactName = name; }
     void setOrganizationName(const std::string_view name) { m_organizationName = name; }
 

--- a/src/framework/graphics/bitmapfont.h
+++ b/src/framework/graphics/bitmapfont.h
@@ -26,6 +26,7 @@
 
 #include <framework/otml/declarations.h>
 
+#include <string>
 #include <utility>
 
 class BitmapFont
@@ -79,6 +80,7 @@ private:
     /// Calculates each font character by inspecting font bitmap
     void calculateGlyphsWidthsAutomatically(const ImagePtr& image, const Size& glyphSize);
     void updateColors(std::vector<std::pair<int, Color>>* colors, int pos, int newTextLen);
+    [[nodiscard]] std::string encodeText(std::string_view text) const;
 
     std::string m_name;
     int m_glyphHeight{ 0 };
@@ -88,4 +90,5 @@ private:
     TexturePtr m_texture;
     Rect m_glyphsTextureCoords[256];
     Size m_glyphsSize[256];
+    std::string m_charset{ "cp1252" };
 };

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -129,6 +129,7 @@ void Application::registerLuaFunctions()
     // Application
     g_lua.registerSingletonClass("g_app");
     g_lua.bindSingletonFunction("g_app", "setName", &Application::setName, static_cast<Application*>(&g_app));
+    g_lua.bindSingletonFunction("g_app", "setCharset", &Application::setCharset, static_cast<Application*>(&g_app));
     g_lua.bindSingletonFunction("g_app", "setCompactName", &Application::setCompactName, static_cast<Application*>(&g_app));
     g_lua.bindSingletonFunction("g_app", "setOrganizationName", &Application::setOrganizationName, static_cast<Application*>(&g_app));
     g_lua.bindSingletonFunction("g_app", "isRunning", &Application::isRunning, static_cast<Application*>(&g_app));

--- a/src/framework/platform/x11window.cpp
+++ b/src/framework/platform/x11window.cpp
@@ -23,9 +23,11 @@
 #if !defined WIN32 && !defined ANDROID && !defined __EMSCRIPTEN__
 
 #include "x11window.h"
-#include <framework/core/resourcemanager.h>
 #include <framework/core/eventdispatcher.h>
+#include <framework/core/graphicalapplication.h>
+#include <framework/core/resourcemanager.h>
 #include <framework/graphics/image.h>
+#include <framework/stdext/string.h>
 #include <unistd.h>
 
 #define LSB_BIT_SET(p, n) (p[(n)/8] |= (1 <<((n)%8)))
@@ -718,7 +720,7 @@ void X11Window::poll()
                         sizeof(typeList));
                     respond.xselection.property = req->property;
                 } else {
-                    std::string clipboardText = stdext::latin1_to_utf8(m_clipboardText);
+                    std::string clipboardText = m_clipboardText;
                     XChangeProperty(m_display,
                         req->requestor,
                         req->property, req->target,
@@ -1096,9 +1098,9 @@ std::string X11Window::getClipboardText()
             (uint8_t**)&data);
         if (len > 0) {
             if (stdext::is_valid_utf8(data))
-                clipboardText = stdext::utf8_to_latin1(data);
-            else
                 clipboardText = data;
+            else
+                clipboardText = stdext::charset_to_utf8(data, g_app.getCharset());
         }
     }
 

--- a/src/framework/stdext/string.cpp
+++ b/src/framework/stdext/string.cpp
@@ -21,9 +21,12 @@
  */
 
 #include <algorithm>
-#include <ranges>
-#include <vector>
+#include <array>
 #include <charconv>
+#include <cctype>
+#include <ranges>
+#include <unordered_map>
+#include <vector>
 
 #include "exception.h"
 #include "types.h"
@@ -89,41 +92,194 @@ namespace stdext
         return true;
     }
 
-    [[nodiscard]] std::string utf8_to_latin1(std::string_view src) {
-        std::string out;
-        out.reserve(src.size()); // Reserve memory to avoid multiple allocations
-        for (size_t i = 0; i < src.size(); ++i) {
-            uint8_t c = static_cast<uint8_t>(src[i]);
-            if ((c >= 32 && c < 128) || c == 0x0d || c == 0x0a || c == 0x09) {
-                out += c;
-            } else if (c == 0xc2 || c == 0xc3) {
-                if (i + 1 < src.size()) {
-                    uint8_t c2 = static_cast<uint8_t>(src[++i]);
-                    out += (c == 0xc2) ? c2 : (c2 + 64);
-                }
+    namespace
+    {
+        constexpr char32_t REPLACEMENT_CHARACTER = 0xFFFD;
+
+        struct CharsetDefinition
+        {
+            std::array<char32_t, 128> forward{};
+            std::unordered_map<char32_t, uint8_t> reverse;
+        };
+
+        CharsetDefinition makeCharsetDefinition(const std::array<char32_t, 128>& forward)
+        {
+            CharsetDefinition def;
+            def.forward = forward;
+            for (size_t i = 0; i < forward.size(); ++i) {
+                const char32_t codepoint = forward[i];
+                if (codepoint != REPLACEMENT_CHARACTER && codepoint != 0)
+                    def.reverse.emplace(codepoint, static_cast<uint8_t>(i + 128));
+            }
+            return def;
+        }
+
+        const CharsetDefinition& fetchCharsetDefinition(const std::string_view charset)
+        {
+            static const CharsetDefinition CP1250 = makeCharsetDefinition({
+                0x20AC, 0xFFFD, 0x201A, 0xFFFD, 0x201E, 0x2026, 0x2020, 0x2021,
+                0xFFFD, 0x2030, 0x0160, 0x2039, 0x015A, 0x0164, 0x017D, 0x0179,
+                0xFFFD, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014,
+                0xFFFD, 0x2122, 0x0161, 0x203A, 0x015B, 0x0165, 0x017E, 0x017A,
+                0x00A0, 0x02C7, 0x02D8, 0x0141, 0x00A4, 0x0104, 0x00A6, 0x00A7,
+                0x00A8, 0x00A9, 0x015E, 0x00AB, 0x00AC, 0x00AD, 0x00AE, 0x017B,
+                0x00B0, 0x00B1, 0x02DB, 0x0142, 0x00B4, 0x00B5, 0x00B6, 0x00B7,
+                0x00B8, 0x0105, 0x015F, 0x00BB, 0x013D, 0x02DD, 0x013E, 0x017C,
+                0x0154, 0x00C1, 0x00C2, 0x0102, 0x00C4, 0x0139, 0x0106, 0x00C7,
+                0x010C, 0x00C9, 0x0118, 0x00CB, 0x011A, 0x00CD, 0x00CE, 0x010E,
+                0x0110, 0x0143, 0x0147, 0x00D3, 0x00D4, 0x0150, 0x00D6, 0x00D7,
+                0x0158, 0x016E, 0x00DA, 0x0170, 0x00DC, 0x00DD, 0x0162, 0x00DF,
+                0x0155, 0x00E1, 0x00E2, 0x0103, 0x00E4, 0x013A, 0x0107, 0x00E7,
+                0x010D, 0x00E9, 0x0119, 0x00EB, 0x011B, 0x00ED, 0x00EE, 0x010F,
+                0x0111, 0x0144, 0x0148, 0x00F3, 0x00F4, 0x0151, 0x00F6, 0x00F7,
+                0x0159, 0x016F, 0x00FA, 0x0171, 0x00FC, 0x00FD, 0x0163, 0x02D9,
+            });
+
+            static const CharsetDefinition CP1252 = makeCharsetDefinition({
+                0x20AC, 0xFFFD, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021,
+                0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0xFFFD, 0x017D, 0xFFFD,
+                0xFFFD, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014,
+                0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0xFFFD, 0x017E, 0x0178,
+                0x00A0, 0x00A1, 0x00A2, 0x00A3, 0x00A4, 0x00A5, 0x00A6, 0x00A7,
+                0x00A8, 0x00A9, 0x00AA, 0x00AB, 0x00AC, 0x00AD, 0x00AE, 0x00AF,
+                0x00B0, 0x00B1, 0x00B2, 0x00B3, 0x00B4, 0x00B5, 0x00B6, 0x00B7,
+                0x00B8, 0x00B9, 0x00BA, 0x00BB, 0x00BC, 0x00BD, 0x00BE, 0x00BF,
+                0x00C0, 0x00C1, 0x00C2, 0x00C3, 0x00C4, 0x00C5, 0x00C6, 0x00C7,
+                0x00C8, 0x00C9, 0x00CA, 0x00CB, 0x00CC, 0x00CD, 0x00CE, 0x00CF,
+                0x00D0, 0x00D1, 0x00D2, 0x00D3, 0x00D4, 0x00D5, 0x00D6, 0x00D7,
+                0x00D8, 0x00D9, 0x00DA, 0x00DB, 0x00DC, 0x00DD, 0x00DE, 0x00DF,
+                0x00E0, 0x00E1, 0x00E2, 0x00E3, 0x00E4, 0x00E5, 0x00E6, 0x00E7,
+                0x00E8, 0x00E9, 0x00EA, 0x00EB, 0x00EC, 0x00ED, 0x00EE, 0x00EF,
+                0x00F0, 0x00F1, 0x00F2, 0x00F3, 0x00F4, 0x00F5, 0x00F6, 0x00F7,
+                0x00F8, 0x00F9, 0x00FA, 0x00FB, 0x00FC, 0x00FD, 0x00FE, 0x00FF,
+            });
+
+            static const CharsetDefinition EMPTY = makeCharsetDefinition({});
+
+            if (charset == "cp1250")
+                return CP1250;
+            if (charset == "cp1252" || charset == "latin1")
+                return CP1252;
+            return EMPTY;
+        }
+
+        inline std::string normalizeCharset(std::string_view charset)
+        {
+            std::string normalized(charset);
+            std::ranges::transform(normalized, normalized.begin(), [](const unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            return normalized;
+        }
+
+        inline char32_t decodeUtf8Char(const std::string_view src, size_t& index)
+        {
+            const uint8_t lead = static_cast<uint8_t>(src[index]);
+            if (lead < 0x80) {
+                ++index;
+                return lead;
+            }
+
+            size_t extraBytes = 0;
+            char32_t codepoint = 0;
+            if ((lead & 0xE0) == 0xC0) {
+                extraBytes = 1;
+                codepoint = lead & 0x1F;
+            } else if ((lead & 0xF0) == 0xE0) {
+                extraBytes = 2;
+                codepoint = lead & 0x0F;
+            } else if ((lead & 0xF8) == 0xF0) {
+                extraBytes = 3;
+                codepoint = lead & 0x07;
             } else {
-                // Skip multi-byte characters
-                while (i + 1 < src.size() && (src[i + 1] & 0xC0) == 0x80) {
-                    ++i;
+                ++index;
+                return '?';
+            }
+
+            if (index + extraBytes >= src.size()) {
+                index = src.size();
+                return '?';
+            }
+
+            for (size_t i = 1; i <= extraBytes; ++i) {
+                const uint8_t byte = static_cast<uint8_t>(src[index + i]);
+                if ((byte & 0xC0) != 0x80) {
+                    index += i;
+                    return '?';
                 }
+                codepoint = (codepoint << 6) | (byte & 0x3F);
+            }
+            index += extraBytes + 1;
+            return codepoint;
+        }
+
+        inline void appendUtf8(std::string& out, char32_t codepoint)
+        {
+            if (codepoint <= 0x7F) {
+                out.push_back(static_cast<char>(codepoint));
+            } else if (codepoint <= 0x7FF) {
+                out.push_back(static_cast<char>(0xC0 | (codepoint >> 6)));
+                out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+            } else if (codepoint <= 0xFFFF) {
+                out.push_back(static_cast<char>(0xE0 | (codepoint >> 12)));
+                out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+                out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+            } else {
+                out.push_back(static_cast<char>(0xF0 | (codepoint >> 18)));
+                out.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+                out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+                out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
             }
         }
+    }
+
+    [[nodiscard]] std::string utf8_to_charset(const std::string_view src, const std::string_view charset)
+    {
+        const std::string normalized = normalizeCharset(charset);
+        if (normalized.empty() || normalized == "utf-8" || normalized == "utf8")
+            return std::string(src);
+
+        const auto& definition = fetchCharsetDefinition(normalized);
+        std::string out;
+        out.reserve(src.size());
+
+        for (size_t i = 0; i < src.size();) {
+            const char32_t codepoint = decodeUtf8Char(src, i);
+            if (codepoint < 128) {
+                out.push_back(static_cast<char>(codepoint));
+                continue;
+            }
+
+            const auto it = definition.reverse.find(codepoint);
+            out.push_back(static_cast<char>(it != definition.reverse.end() ? it->second : '?'));
+        }
+
         return out;
     }
 
-    [[nodiscard]] std::string latin1_to_utf8(std::string_view src) {
+    [[nodiscard]] std::string charset_to_utf8(const std::string_view src, const std::string_view charset)
+    {
+        const std::string normalized = normalizeCharset(charset);
+        if (normalized.empty() || normalized == "utf-8" || normalized == "utf8")
+            return std::string(src);
+
+        const auto& definition = fetchCharsetDefinition(normalized);
         std::string out;
-        out.reserve(src.size() * 2); // Reserve space to reduce allocations
-        for (uint8_t c : src) {
-            if ((c >= 32 && c < 128) || c == 0x0d || c == 0x0a || c == 0x09) {
-                out += c; // Directly append ASCII characters
-            } else {
-                out.push_back(0xc2 + (c > 0xbf));
-                out.push_back(0x80 + (c & 0x3f));
+        out.reserve(src.size() * 2);
+
+        for (const uint8_t c : src) {
+            char32_t codepoint = c;
+            if (c >= 128) {
+                const char32_t mapped = definition.forward[c - 128];
+                codepoint = mapped == REPLACEMENT_CHARACTER || mapped == 0 ? '?' : mapped;
             }
+            appendUtf8(out, codepoint);
         }
+
         return out;
     }
+
+    [[nodiscard]] std::string utf8_to_latin1(std::string_view src) { return utf8_to_charset(src, "cp1252"); }
+
+    [[nodiscard]] std::string latin1_to_utf8(std::string_view src) { return charset_to_utf8(src, "cp1252"); }
 
 #ifdef WIN32
 #include <winsock2.h>

--- a/src/framework/stdext/string.h
+++ b/src/framework/stdext/string.h
@@ -49,6 +49,8 @@ namespace stdext
     void replace_all(std::string& str, std::string_view search, std::string_view replacement);
 
     [[nodiscard]] bool is_valid_utf8(std::string_view src);
+    [[nodiscard]] std::string utf8_to_charset(std::string_view src, std::string_view charset);
+    [[nodiscard]] std::string charset_to_utf8(std::string_view src, std::string_view charset);
     [[nodiscard]] std::string utf8_to_latin1(std::string_view src);
     [[nodiscard]] std::string latin1_to_utf8(std::string_view src);
 


### PR DESCRIPTION
## Summary
- add cp1250-capable font declarations and locale charset selection for Polish UI text
- extend text encoding helpers and bitmap font rendering to operate on UTF-8 input with cp1250 glyph maps
- adjust platform input and clipboard paths to preserve Unicode characters across Windows and X11

## Testing
- cmake --preset linux-release *(fails: missing vcpkg toolchain and Ninja build tool in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4789104c883328f5b0c49c682f0a2